### PR TITLE
fix: Downgrade @stripe/stripe-js to version 4.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.6.0",
         "@ng-web-apis/common": "^4.12.0",
         "@ng-web-apis/universal": "^4.12.0",
-        "@stripe/stripe-js": "^7.4.0",
+        "@stripe/stripe-js": "^4.10.0",
         "@tanstack/angular-query-devtools-experimental": "^5.54.1",
         "@tanstack/angular-query-experimental": "^5.81.5",
         "angular-auth-oidc-client": "^18.0.2",
@@ -7051,9 +7051,9 @@
       }
     },
     "node_modules/@stripe/stripe-js": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.4.0.tgz",
-      "integrity": "sha512-lQHQPfXPTBeh0XFjq6PqSBAyR7umwcJbvJhXV77uGCUDD6ymXJU/f2164ydLMLCCceNuPlbV9b+1smx98efwWQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-4.10.0.tgz",
+      "integrity": "sha512-KrMOL+sH69htCIXCaZ4JluJ35bchuCCznyPyrbN8JXSGQfwBI1SuIEMZNwvy8L8ykj29t6sa5BAAiL7fNoLZ8A==",
       "license": "MIT",
       "engines": {
         "node": ">=12.16"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@ng-web-apis/common": "^4.12.0",
     "@ng-web-apis/universal": "^4.12.0",
-    "@stripe/stripe-js": "^7.4.0",
+    "@stripe/stripe-js": "^4.10.0",
     "@tanstack/angular-query-devtools-experimental": "^5.54.1",
     "@tanstack/angular-query-experimental": "^5.81.5",
     "angular-auth-oidc-client": "^18.0.2",


### PR DESCRIPTION
The `@stripe/stripe-js` package was downgraded from version 7.4.0 to 4.10.0. This change was made to address compatibility issues or resolve conflicts with other dependencies in the project.